### PR TITLE
Input field modification on signup and update profile 

### DIFF
--- a/src/components/login/Signup.js
+++ b/src/components/login/Signup.js
@@ -84,11 +84,11 @@ function SignUp () {
                       <h5>Practice Information</h5>
                     </div>
                     <div className="form-input">
-                      <div className="col-md-12">
+                      {/*<div className="col-md-12">
                         <input type="text" className="form-control" placeholder="Practice Name" 
                         name="practiceName" ref={register({required:true})}/>
                         {errors.practiceName && errors.practiceName.type === "required" && (<p className="text-danger">Practice Name field is required</p>)}
-                      </div>
+        </div>*/}
                       <div className="col-md-12">
                         <input type="text" className="form-control" placeholder="Office Name" 
                         name="officeName" ref={register({required:true})}/>

--- a/src/components/myaccount/editAddr.js
+++ b/src/components/myaccount/editAddr.js
@@ -10,6 +10,8 @@ class EditAddr extends Component {
         super(props);
         this.state = {
             page: props.location.state.page,
+            input: {},
+            errors: {},
             monActive: false,
             tueActive: false,
             wedActive: false,
@@ -17,7 +19,80 @@ class EditAddr extends Component {
             friActive: false,
             satActive: false,
             sunActive: false,
+        };
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChange(event) {
+        let input = this.state.input;
+        input[event.target.name] = event.target.value;
+      
+        this.setState({
+          input
+        });
+      }
+         
+    handleSubmit(event) {
+        event.preventDefault();
+        
+        if(this.validate()){
+            //console.log(this.state);
+        
+            let input = {};
+            input["doctorName"] = "";
+            input["officeName"] = "";
+            input["address"] = "";
+            input["city"] = "";
+            input["state"] = "";
+            input["zip"] = "";
+            this.setState({input:input});
+        
+            //alert('Demo Form is submited');
         }
+    }
+
+    validate(){
+        let input = this.state.input;
+        let errors = {};
+        let isValid = true;
+    
+        if (!input["doctorName"]) {
+            isValid = false;
+            errors["doctorName"] = "Please enter your Doctor Name.";
+        }
+
+        if (!input["officeName"]) {
+            isValid = false;
+            errors["officeName"] = "Please enter your Office Name.";
+        }
+
+        if (!input["address"]) {
+            isValid = false;
+            errors["address"] = "Please enter Address.";
+        }
+    
+        if (!input["city"]) {
+            isValid = false;
+            errors["city"] = "Please enter City.";
+        }
+            
+        if (!input["state"]) {
+            isValid = false;
+            errors["state"] = "Please enter State.";
+        }
+        
+        if (!input["zip"]) {
+            isValid = false;
+            errors["zip"] = "Please enter Zip.";
+        }
+
+        this.setState({
+          errors: errors
+        });
+    
+        return isValid;
     }
 
     MonClicked = (e) => { 
@@ -69,6 +144,7 @@ class EditAddr extends Component {
                             : <h1 className="title-wording">Edit Addresses</h1>
                         }
                     </div>
+                    <form onSubmit={this.handleSubmit}>
                     <div className="editAddr default pt-3">
                         <div className="officeInfo mb-3">                
                             <div className="part-header mb-4">
@@ -76,34 +152,50 @@ class EditAddr extends Component {
                             </div>
                             <div className="part-value">
                                 <div className="form-row">
-                                    <div className="form-group col-md-9">
-                                        <div><span>Doctor Name/ Office Name</span></div>
-                                        <input type="text" className="form-control" name="doctorOrOfficeName"/>                                                
+                                    <div className="form-group col-md-6">
+                                        <div><span>Doctor Name</span></div>
+                                        <input type="text" className="form-control" name="doctorName"
+                                        value={this.state.input.doctorName} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.doctorName}</div>
                                     </div>
-                                    <div className="form-group col-md-3">
-                                        <div><span>License#</span></div>
-                                        <input type="text" className="form-control" name="licenseNum"/>
-                                    </div>  
+                                    <div className="form-group col-md-6">
+                                        <div><span>Office Name</span></div>
+                                        <input type="text" className="form-control" name="officeName"
+                                        value={this.state.input.officeName} onChange={this.handleChange}/>  
+                                        <div className="text-danger">{this.state.errors.officeName}</div>                                              
+                                    </div>
                                 </div>
                                 <div className="form-row">
-                                    <div className="form-group col-md-12">
-                                        <div><span>Address Line1</span></div>
-                                        <input type="text" className="form-control" name="address"/>                                                
+                                    <div className="form-group col-md-9">
+                                        <div><span>Address</span></div>
+                                        <input type="text" className="form-control" name="address"
+                                        value={this.state.input.address} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.address}</div>                                                 
+                                    </div>
+                                    <div className="form-group col-md-3">
+                                        <div><span>Suite / Building</span></div>
+                                        <input type="text" className="form-control" name="suite"/>
                                     </div>
                                 </div>
                                 <div className="form-row">
                                     <div className="form-group col-md-5">
                                         <div><span>City</span></div>
-                                        <input type="text" className="form-control" name="city"/>                                                
+                                        <input type="text" className="form-control" name="city"
+                                        value={this.state.input.city} onChange={this.handleChange}/> 
+                                        <div className="text-danger">{this.state.errors.city}</div>                                                  
                                     </div>
                                     <div className="form-group col-md-3">
                                         <div><span>State</span></div>
-                                        <input type="text" className="form-control" name="state"/>  
+                                        <input type="text" className="form-control" name="state"
+                                        value={this.state.input.state} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.state}</div>    
                                     </div> 
                                     <div className="form-group col-md-2">
                                         <div><span>Zip</span></div>
-                                        <input type="text" className="form-control" name="zip"/>  
-                                    </div> 
+                                        <input type="text" className="form-control" name="zip"
+                                        value={this.state.input.zip} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.zip}</div>   
+                                    </div>  
                                 </div>
                             </div>
                         </div>
@@ -167,9 +259,10 @@ class EditAddr extends Component {
                         </div>
                         <div className="save mt-4 mb-5">
                             <div className="save-btn">
-                                <input type="button" value="Save" className="btn btn-primary btn-lg" />
+                                <input type="submit" value="Save" className="btn btn-primary btn-lg" />
                             </div>
                         </div>
+                        </form>
                     </div>
                 </div> 
         );

--- a/src/components/myaccount/updateMyInfo.js
+++ b/src/components/myaccount/updateMyInfo.js
@@ -211,11 +211,15 @@ class UpdateMyInfo extends Component {
                                 </div>
                                 
                                 <div className="form-row">
-                                    <div className="form-group col-md-12">
-                                        <div><span>Address Line1</span></div>
+                                    <div className="form-group col-md-9">
+                                        <div><span>Address</span></div>
                                         <input type="text" className="form-control" name="address"
                                         value={this.state.input.address} onChange={this.handleChange}/>
                                         <div className="text-danger">{this.state.errors.address}</div>                                                 
+                                    </div>
+                                    <div className="form-group col-md-3">
+                                        <div><span>Suite / Building</span></div>
+                                        <input type="text" className="form-control" name="suite"/>
                                     </div>
                                 </div>
                                 <div className="form-row">

--- a/src/components/myaccount/updateMyInfo.js
+++ b/src/components/myaccount/updateMyInfo.js
@@ -98,8 +98,41 @@ class UpdateMyInfo extends Component {
                                         <input type="text" className="form-control" name="zip"/>  
                                     </div> 
                                 </div>
+                                <div className="form-row">
+                                    <div className="form-group col-md-6">
+                                        <div><span>Phone</span></div>
+                                        <input type="text" className="form-control" name="phone"/>                                                
+                                    </div>
+                                    <div className="form-group col-md-6">
+                                        <div><span>Email</span></div>
+                                        <input type="text" className="form-control" name="email" disabled={true}/>  
+                                    </div> 
+                                </div>
                             </div>
                         </div>
+                        
+                        <div className="officeInfo mainContactInfo mb-3">
+                            <div className="part-header mb-4">
+                                <h3><b>Main Contact</b></h3>
+                            </div>
+                            <div className="part-value">
+                                <div className="form-row">
+                                    <div className="form-group col-md-4">
+                                        <div><span>Main Contact First Name</span></div>
+                                        <input type="text" className="form-control" name="mfName"/>                                                
+                                    </div>
+                                    <div className="form-group col-md-4">
+                                        <div><span>Main Contact Last Name</span></div>
+                                        <input type="text" className="form-control" name="mlName"/>  
+                                    </div> 
+                                    <div className="form-group col-md-4">
+                                        <div><span>Main Contact Email</span></div>
+                                        <input type="text" className="form-control" name="mEmail"/>  
+                                    </div> 
+                                </div>
+                            </div>
+                        </div>
+
                         <div className="officeInfo date-and-hours">
                             <div className="part-header mb-4">
                                 <h3><b>Office Hours</b></h3>

--- a/src/components/myaccount/updateMyInfo.js
+++ b/src/components/myaccount/updateMyInfo.js
@@ -9,6 +9,8 @@ class UpdateMyInfo extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            input: {},
+            errors: {},
             monActive: false,
             tueActive: false,
             wedActive: false,
@@ -16,9 +18,127 @@ class UpdateMyInfo extends Component {
             friActive: false,
             satActive: false,
             sunActive: false,
+        };
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChange(event) {
+        let input = this.state.input;
+        input[event.target.name] = event.target.value;
+      
+        this.setState({
+          input
+        });
+      }
+         
+    handleSubmit(event) {
+        event.preventDefault();
+        
+        if(this.validate()){
+            console.log(this.state);
+        
+            let input = {};
+            input["licenseNum"] = "";
+            input["officeName"] = "";
+            input["address"] = "";
+            input["city"] = "";
+            input["state"] = "";
+            input["zip"] = "";
+            input["mfName"] = "";
+            input["mlName"] = "";
+            input["mEmail"] = "";
+            input["phone"] = "";
+            this.setState({input:input});
+        
+            //alert('Demo Form is submited');
         }
     }
 
+    validate(){
+        let input = this.state.input;
+        let errors = {};
+        let isValid = true;
+    
+        if (!input["licenseNum"]) {
+            isValid = false;
+            errors["licenseNum"] = "Please enter your License Number.";
+        }
+
+        if (!input["officeName"]) {
+            isValid = false;
+            errors["officeName"] = "Please enter your Office Name.";
+        }
+
+        if (!input["address"]) {
+            isValid = false;
+            errors["address"] = "Please enter Address.";
+        }
+    
+        if (!input["city"]) {
+            isValid = false;
+            errors["city"] = "Please enter City.";
+        }
+            
+        if (!input["state"]) {
+            isValid = false;
+            errors["state"] = "Please enter State.";
+        }
+        
+        if (!input["zip"]) {
+            isValid = false;
+            errors["zip"] = "Please enter Zip.";
+        }
+
+        if (!input["mfName"]) {
+            isValid = false;
+            errors["mfName"] = "Please enter Main Contact First Name.";
+        }
+
+        if (!input["mlName"]) {
+            isValid = false;
+            errors["mlName"] = "Please enter Main Contact Last Name.";
+        }
+
+        if (!input["mEmail"]) {
+          isValid = false;
+          errors["mEmail"] = "Please enter Main Contact Email Address.";
+        }
+    
+        if (typeof input["mEmail"] !== "undefined") {
+            
+          var pattern = new RegExp(/^(("[\w-\s]+")|([\w-]+(?:\.[\w-]+)*)|("[\w-\s]+")([\w-]+(?:\.[\w-]+)*))(@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][0-9]\.|1[0-9]{2}\.|[0-9]{1,2}\.))((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){2}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\]?$)/i);
+          if (!pattern.test(input["mEmail"])) {
+            isValid = false;
+            errors["mEmail"] = "Please enter valid email address.";
+          }
+        }
+    
+        if (!input["phone"]) {
+          isValid = false;
+          errors["phone"] = "Please enter your phone number.";
+        }
+    
+        if (typeof input["phone"] !== "undefined") {
+            
+          var pattern = new RegExp(/^[0-9\b]+$/);
+          if (!pattern.test(input["phone"])) {
+            isValid = false;
+            errors["phone"] = "Please enter only number.";
+          }else if(input["phone"].length != 10){
+            isValid = false;
+            errors["phone"] = "Please enter valid phone number.";
+          }
+        }
+    
+        this.setState({
+          errors: errors
+        });
+    
+        return isValid;
+    }
+    
     MonClicked = (e) => { 
         const currentState = this.state.monActive;
         this.setState({ monActive: !currentState }); 
@@ -62,6 +182,7 @@ class UpdateMyInfo extends Component {
                     <div className="myacct-banner text-left">
                         <h1 className="title-wording">Update Profile</h1>
                     </div>
+                    <form onSubmit={this.handleSubmit}>
                     <div className="update-myinfo default pt-3">
                         <div className="officeInfo mb-3">                
                             <div className="part-header mb-4">
@@ -70,38 +191,59 @@ class UpdateMyInfo extends Component {
                             <div className="part-value">
                                 <div className="form-row">
                                     <div className="form-group col-md-9">
-                                        <div><span>Doctor Name/ Office Name</span></div>
-                                        <input type="text" className="form-control" name="doctorOrOfficeName"/>                                                
+                                        <div><span>Doctor Name</span></div>
+                                        <input type="text" className="form-control" name="doctorName" disabled={true}/>
                                     </div>
                                     <div className="form-group col-md-3">
                                         <div><span>License#</span></div>
-                                        <input type="text" className="form-control" name="licenseNum"/>
+                                        <input type="text" className="form-control" name="licenseNum"
+                                        value={this.state.input.licenseNum} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.licenseNum}</div>
                                     </div>  
                                 </div>
                                 <div className="form-row">
                                     <div className="form-group col-md-12">
+                                        <div><span>Office Name</span></div>
+                                        <input type="text" className="form-control" name="officeName"
+                                        value={this.state.input.officeName} onChange={this.handleChange}/>  
+                                        <div className="text-danger">{this.state.errors.officeName}</div>                                              
+                                    </div>
+                                </div>
+                                
+                                <div className="form-row">
+                                    <div className="form-group col-md-12">
                                         <div><span>Address Line1</span></div>
-                                        <input type="text" className="form-control" name="address"/>                                                
+                                        <input type="text" className="form-control" name="address"
+                                        value={this.state.input.address} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.address}</div>                                                 
                                     </div>
                                 </div>
                                 <div className="form-row">
                                     <div className="form-group col-md-5">
                                         <div><span>City</span></div>
-                                        <input type="text" className="form-control" name="city"/>                                                
+                                        <input type="text" className="form-control" name="city"
+                                        value={this.state.input.city} onChange={this.handleChange}/> 
+                                        <div className="text-danger">{this.state.errors.city}</div>                                                  
                                     </div>
                                     <div className="form-group col-md-3">
                                         <div><span>State</span></div>
-                                        <input type="text" className="form-control" name="state"/>  
+                                        <input type="text" className="form-control" name="state"
+                                        value={this.state.input.state} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.state}</div>    
                                     </div> 
                                     <div className="form-group col-md-2">
                                         <div><span>Zip</span></div>
-                                        <input type="text" className="form-control" name="zip"/>  
+                                        <input type="text" className="form-control" name="zip"
+                                        value={this.state.input.zip} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.zip}</div>   
                                     </div> 
                                 </div>
                                 <div className="form-row">
                                     <div className="form-group col-md-6">
                                         <div><span>Phone</span></div>
-                                        <input type="text" className="form-control" name="phone"/>                                                
+                                        <input type="text" className="form-control" name="phone"
+                                        value={this.state.input.phone} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.phone}</div>                                                 
                                     </div>
                                     <div className="form-group col-md-6">
                                         <div><span>Email</span></div>
@@ -119,15 +261,21 @@ class UpdateMyInfo extends Component {
                                 <div className="form-row">
                                     <div className="form-group col-md-4">
                                         <div><span>Main Contact First Name</span></div>
-                                        <input type="text" className="form-control" name="mfName"/>                                                
+                                        <input type="text" className="form-control" name="mfName"
+                                        value={this.state.input.mfName} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.mfName}</div>                                                
                                     </div>
                                     <div className="form-group col-md-4">
                                         <div><span>Main Contact Last Name</span></div>
-                                        <input type="text" className="form-control" name="mlName"/>  
+                                        <input type="text" className="form-control" name="mlName"
+                                        value={this.state.input.mlName} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.mlName}</div>    
                                     </div> 
                                     <div className="form-group col-md-4">
                                         <div><span>Main Contact Email</span></div>
-                                        <input type="text" className="form-control" name="mEmail"/>  
+                                        <input type="text" className="form-control" name="mEmail"
+                                        value={this.state.input.mEmail} onChange={this.handleChange}/>
+                                        <div className="text-danger">{this.state.errors.mEmail}</div>  
                                     </div> 
                                 </div>
                             </div>
@@ -187,9 +335,10 @@ class UpdateMyInfo extends Component {
                     
                     <div className="save mt-4">
                         <div className="save-btn">
-                            <input type="button" value="Save" className="btn btn-primary btn-lg float-right mb-4" />
+                            <input type="submit" value="Save" className="btn btn-primary btn-lg float-right mb-4" />
                         </div>
                     </div>
+                    </form>
                 </div>
             </div> 
         );

--- a/src/components/myaccount/updateMyInfo.js
+++ b/src/components/myaccount/updateMyInfo.js
@@ -37,7 +37,7 @@ class UpdateMyInfo extends Component {
         event.preventDefault();
         
         if(this.validate()){
-            console.log(this.state);
+            //console.log(this.state);
         
             let input = {};
             input["licenseNum"] = "";


### PR DESCRIPTION
### **Description:**
This story is Input field modification on signup page and update profile page to allow users to store account information they need while using the portal.

- Removed 'Practice Name' field from signup page which is not needed.
- Added 'Phone/ Email(not editable)/ Main Contact First and Last Name/ Main Contact Email field.

![4-4 update profile](https://user-images.githubusercontent.com/78044058/123691726-ce755280-d80a-11eb-9bd8-a33e18a113a4.png)
